### PR TITLE
Add the ability to enrich the CloudWatch events

### DIFF
--- a/cloudwatch/README.md
+++ b/cloudwatch/README.md
@@ -41,6 +41,7 @@ You have two options to deploy:
     | `FORMAT` | `json` or `text`. If `json`, the lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. | `text` |
     | `URL` | **Required**. Your Logz.io listener URL. If you are in the EU region, use `https://listener-eu.logz.io:8071`. Otherwise, use `https://listener.logz.io:8071`. If you don't know your region, check your login URL. _app-eu.logz.io_ is the EU data center. _app.logz.io_ is the US data center. |
     | `COMPRESS` | If `true`, the Lambda will send compressed logs. If `false`, the Lambda will send uncompressed logs. | `false` |
+    | `ENRICH` | Enriches the CloudWatch events with custom properties at ship time. The format is `key1=value1;key2=value2`. By default is empty. | |
 
 6. In **Basic settings**, we recommend setting **Memory** to 512 MB, and setting **Timeout** to 1 min 0 sec. Keep an eye on your Lambda usage, and adjust these values accordingly.
 7. Leave the other settings as default.
@@ -80,6 +81,7 @@ You have two options to deploy:
     | `LogzioFORMAT` | `json` or `text`. If `json`, the lambda function will attempt to parse the message field as JSON and populate the event data with the parsed fields. | `text` |
     | `LogzioURL` | Your Logz.io listener URL. If you are in the EU region, use `https://listener-eu.logz.io:8071`. Otherwise, use `https://listener.logz.io:8071`. If you don't know your region, check your login URL. _app-eu.logz.io_ is the EU data center. _app.logz.io_ is the US data center. | `https://listener.logz.io:8071` |
     | `LogzioCOMPRESS` | If `true`, the Lambda will send compressed logs. If `false`, the Lambda will send uncompressed logs. | `false` |
+    | `LogzioENRICH` | Enriches the CloudWatch events with custom properties at ship time. The format is `key1=value1;key2=value2`. By default is empty. | |
 
 ## Step 2: Set up CloudWatch log event trigger
 

--- a/cloudwatch/sam-template.yaml
+++ b/cloudwatch/sam-template.yaml
@@ -36,6 +36,7 @@ Parameters:
   LogzioENRICH:
     Type: "String"
     Description: "Enriches the CloudWatch events with custom properties at ship time. The format is `key1=value1;key2=value2`. By default is empty."
+    Default: ""
 
 Outputs:
     LogzioCloudwatchLogsLambda:

--- a/cloudwatch/sam-template.yaml
+++ b/cloudwatch/sam-template.yaml
@@ -33,6 +33,10 @@ Parameters:
     Description: "If true, the Lambda will send compressed logs. If false, the Lambda will send uncompressed logs."
     Default: "false"
 
+  LogzioENRICH:
+    Type: "String"
+    Description: "Enriches the CloudWatch events with custom properties at ship time. The format is `key1=value1;key2=value2`. By default is empty."
+
 Outputs:
     LogzioCloudwatchLogsLambda:
       Description: "Logz.io CW logs lambda ARN"
@@ -55,3 +59,4 @@ Resources:
           TYPE: !Ref LogzioTYPE
           FORMAT: !Ref LogzioFORMAT
           COMPRESS: !Ref LogzioCOMPRESS
+          ENRICH: !Ref LogzioENRICH

--- a/cloudwatch/src/lambda_function.py
+++ b/cloudwatch/src/lambda_function.py
@@ -76,6 +76,16 @@ def _parse_cloudwatch_log(log, aws_logs_data, log_type):
     except (KeyError, ValueError):
         pass
 
+    # If ENRICH has value, add the properties
+    try:
+        if os.environ['ENRICH']:
+            properties_to_enrich = os.environ['ENRICH'].split(";")
+            for property_to_enrich in properties_to_enrich:
+                property_key_value = property_to_enrich.split("=")
+                log[property_key_value[0]] = property_key_value[1]
+    except (KeyError, ValueError):
+        pass
+
 
 def _enrich_logs_data(aws_logs_data, context):
     # type: (dict, 'LambdaContext') -> None

--- a/cloudwatch/tests/lambda_tests.py
+++ b/cloudwatch/tests/lambda_tests.py
@@ -286,6 +286,34 @@ class TestLambdaFunction(unittest.TestCase):
             self.assertEqual(json_body_log['environment'], "testing")
             self.assertEqual(json_body_log['foo'], "bar")
 
+    @httpretty.activate
+    def test_enrich_event_empty(self):
+        os.environ['ENRICH'] = ""
+        event = self._generate_aws_logs_event(self._json_string_builder)
+        httpretty.register_uri(httpretty.POST, self._logzioUrl, body="first", status=200,
+                               content_type="application/json")
+        try:
+            worker.lambda_handler(event['enc'], Context)
+        except Exception:
+            self.fail("Failed on handling a legit event. Expected status_code = 200")
+
+        request = httpretty.HTTPretty.last_request
+        body_logs_list = request.body.splitlines()
+
+        for i in xrange(BODY_SIZE):
+            json_body_log = json.loads(body_logs_list[i])
+            self.assertFalse(hasattr(json_body_log, "environment"))
+
+    @httpretty.activate
+    def test_enrich_event_bad_format(self):
+        os.environ['ENRICH'] = "environment"
+        event = self._generate_aws_logs_event(self._json_string_builder)
+        httpretty.register_uri(httpretty.POST, self._logzioUrl, body="first", status=200,
+                               content_type="application/json")
+
+        with self.assertRaises(IndexError):
+            worker.lambda_handler(event['enc'], Context)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds the ability to enrich the CloudWatch events at ship time. It addresses issue #23.
If the property is set in the correct format (`key1=value1;key2=value2`) the Lambda function will enrich the log with the properties:
```
... LOG EVENT ...
key1: "value1",
key2: "value2"
```
It will allow enriching the log with custom properties, thus querying on Logz.io will be easier.