### PR TITLE
fix enrich mapping on cloudwatch lambda

### DIFF
--- a/cloudwatch/src/lambda_function.py
+++ b/cloudwatch/src/lambda_function.py
@@ -7,7 +7,7 @@ from shipper.shipper import LogzioShipper
 from StringIO import StringIO
 
 KEY_INDEX = 0
-VALUE_INDEX = 0
+VALUE_INDEX = 1
 
 # set logger
 logger = logging.getLogger()


### PR DESCRIPTION
Otherwise with this line:
`additional_data[property_key_value[KEY_INDEX]] = property_key_value[VALUE_INDEX]`
We get `additional_data[key1]=key1` instead of `additional_data[key1]=value1`