### PR TITLE
Removed a faulty packaging method

### DIFF
--- a/cloudwatch/README.md
+++ b/cloudwatch/README.md
@@ -27,8 +27,7 @@ You have two options to deploy:
 #### Upload and configure the Logz.io Lambda shipper
 
 1. Clone the logzio_aws_serverless repo to your machine (https://github.com/logzio/logzio_aws_serverless.git).
-2. `cd` into `logzio_aws_serverless/cloudwatch/`. Zip 'lambda_function.py' and 'shipper.py' with one of these options:
-    - `make build` creates the zip at 'dist/logzio-cloudwatch-log-shipper.zip'
+2. `cd` into `logzio_aws_serverless/cloudwatch/`. Zip 'lambda_function.py' and 'shipper.py' using the following command(s):
     - `mkdir dist; cp -r ../shipper dist/ && cp src/lambda_function.py dist/ && cd dist/ && zip logzio-cloudwatch shipper/* lambda_function.py`
 3. In the **Function code** section of Lambda, choose **Upload a .ZIP file** from the **Code entry type list**.
 4. Click **Upload**, and choose the zip you created on your machine.
@@ -51,8 +50,7 @@ You have two options to deploy:
 **Prerequisites:** AWS CLI and an S3 bucket
 
 1. Clone the logzio_aws_serverless repo to your machine (https://github.com/logzio/logzio_aws_serverless.git).
-2. `cd` into `logzio_aws_serverless/cloudwatch/`. Zip 'lambda_function.py' and 'shipper.py' with one of these options:
-    - `make build` creates the zip at 'dist/logzio-cloudwatch-log-shipper.zip'
+2. `cd` into `logzio_aws_serverless/cloudwatch/`. Zip 'lambda_function.py' and 'shipper.py' using the following command(s):
     - `mkdir dist; cp -r ../shipper dist/ && cp src/lambda_function.py dist/ && cd dist/ && zip logzio-cloudwatch shipper/* lambda_function.py`
 3. Upload the package to your S3 bucket.
  


### PR DESCRIPTION
The "make build" option creates an incorrect directory structure in the package.
Users should use only the second option for packaging.