### PR TITLE
400 status code throws exception

### DIFF
--- a/cloudwatch/tests/lambda_tests.py
+++ b/cloudwatch/tests/lambda_tests.py
@@ -133,8 +133,8 @@ class TestLambdaFunction(unittest.TestCase):
                                 httpretty.Response(body="first", status=400),
                                 httpretty.Response(body="second", status=401),
                             ])
-        with self.assertRaises(BadLogsException):
-            worker.lambda_handler(event['enc'], Context)
+
+        worker.lambda_handler(event['enc'], Context)
 
         with self.assertRaises(UnauthorizedAccessException):
             worker.lambda_handler(event['enc'], Context)

--- a/kinesis/tests/lambda_tests.py
+++ b/kinesis/tests/lambda_tests.py
@@ -127,8 +127,7 @@ class TestLambdaFunction(unittest.TestCase):
                                 httpretty.Response(body="second", status=401),
                             ])
 
-        with self.assertRaises(BadLogsException):
-            worker.lambda_handler(event, None)
+        worker.lambda_handler(event, None)
 
         with self.assertRaises(UnauthorizedAccessException):
             worker.lambda_handler(event, None)

--- a/shipper/shipper.py
+++ b/shipper/shipper.py
@@ -198,7 +198,7 @@ class LogzioShipper(object):
         except BadLogsException as e:
             logger.error("Got 400 code from Logz.io. This means that some of your logs are too big, "
                          "or badly formatted. response: {0}".format(e.message))
-            raise BadLogsException()
+            logger.warning("Dropping logs that cause the bad response...")
         except UnauthorizedAccessException:
             logger.error("You are not authorized with Logz.io! Token OK? dropping logs...")
             raise UnauthorizedAccessException()


### PR DESCRIPTION
When we get '400' response status code, some of the logs in the bulk might be good. We will want to continue sending logs and drop the ones that are badly formatted. 