### PR TITLE
Add test events generator to cw integration

### DIFF
--- a/python3/cloudwatch/test_events/README.md
+++ b/python3/cloudwatch/test_events/README.md
@@ -1,1 +1,31 @@
-## Test events
+# Working with test events
+
+You can generate test events using the Logz.io Lambda test events generator and add these events to your Lambda function. This functionality is currently only available on Linux & macOS.
+
+
+## Generate a test event
+
+1. In your terminal, run the following command:
+  
+   ```shell
+   bash <(curl -s https://raw.githubusercontent.com/logzio/logzio_aws_serverless/tree/master/python3/cloudwatch/test_events/test_event_generator.sh)      
+   ```
+               
+   This script generates a test event with a UTC timestamp of the moment you run the script.
+               
+2. Copy the output JSON.
+
+## Add the generated test event to your Lambda function
+
+1. Select the Lambda function that you need to add the test event to.
+2. Open the **Test** tab.
+3. Select **New event**.
+4. In the **Template** field, select **CloudWatch Logs**.
+5. In the **Name** field, enter a name for the test event. No specific naming convention is required. 
+6. Populate the body field with the output JSON of the test event generated in the previous step.
+7. Select **Format** to format the test event.
+8. Select **Save changes**.
+
+## Run the test event
+
+To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account.

--- a/python3/cloudwatch/test_events/README.md
+++ b/python3/cloudwatch/test_events/README.md
@@ -1,3 +1,4 @@
+
 # Working with test events
 
 You can generate test events using the Logz.io Lambda test events generator and add these events to your Lambda function. This functionality is currently only available on Linux & macOS.
@@ -29,3 +30,13 @@ You can generate test events using the Logz.io Lambda test events generator and 
 ## 3. Run the test event
 
 To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account.
+
+The test should produce 2 logs in your Logz.io account, with the following messages:
+
+```shell
+[ERROR] Logz.io cloudwatch test log1
+```
+
+```shell
+[ERROR] Logz.io cloudwatch test log2
+```

--- a/python3/cloudwatch/test_events/README.md
+++ b/python3/cloudwatch/test_events/README.md
@@ -3,7 +3,7 @@
 You can generate test events using the Logz.io Lambda test events generator and add these events to your Lambda function. This functionality is currently only available on Linux & macOS.
 
 
-## Generate a test event
+## 1. Generate a test event
 
 1. In your terminal, run the following command:
   
@@ -15,7 +15,7 @@ You can generate test events using the Logz.io Lambda test events generator and 
                
 2. Copy the output JSON.
 
-## Add the generated test event to your Lambda function
+## 2. Add the generated test event to your Lambda function
 
 1. Select the Lambda function that you need to add the test event to.
 2. Open the **Test** tab.
@@ -26,6 +26,6 @@ You can generate test events using the Logz.io Lambda test events generator and 
 7. Select **Format** to format the test event.
 8. Select **Save changes**.
 
-## Run the test event
+## 3. Run the test event
 
 To run the test event, select **Test** in the **Test** tab. The Lambda function will run and generate two logs in your account.

--- a/python3/cloudwatch/test_events/README.md
+++ b/python3/cloudwatch/test_events/README.md
@@ -1,0 +1,1 @@
+## Test events

--- a/python3/cloudwatch/test_events/test_event_generator.sh
+++ b/python3/cloudwatch/test_events/test_event_generator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+## TIMESTAMP IS IN UTC
+NOW_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+LOGS=$(printf '{"messageType":"DATA_MESSAGE","owner":"123456789123","logGroup":"testLogGroup","logStream":"testLogStream","subscriptionFilters":["testFilter"],"logEvents":[{"id":"eventId1","timestamp":"%s","message":"[ERROR] Logz.io cloudwatch test log1"},{"id":"eventId2","timestamp":"%s","message":"[ERROR] Logz.io cloudwatch test log2"}]}' $NOW_TIMESTAMP $NOW_TIMESTAMP)
+DATA=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+        DATA=$(echo $LOGS | gzip | base64)
+else
+        DATA=$(echo $LOGS | gzip | base64 -w0)
+fi
+TEST_EVENT=$(printf '{
+  "awslogs": {
+    "data": "%s"
+  }
+}' $DATA)
+echo $TEST_EVENT


### PR DESCRIPTION
Since cw test events are zipped & encoded, users can't use the default template for cw test events that aws offers in the lambda testing.
This PR adds a test event generator, that creates a sample test event with the UTC timestamp of the time the script runs.
That way, users can use the generated test event to test the lambda function before using it.