### PR TITLE
Ignore very large cloudwatch logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+__pycache__/
+*.py[cod]

--- a/python3/cloudwatch/sam-template.yaml
+++ b/python3/cloudwatch/sam-template.yaml
@@ -53,6 +53,11 @@ Parameters:
     Description: "CloudWatch Log Group name from where you want to send logs."
     Default: ""
 
+  MaxLogSize:
+    Type: Number
+    Description: "Maximum size of the log which needs to be push to Logzio"
+    Default: 10000
+
 Outputs:
     LogzioCloudwatchLogsLambda:
       Description: "Logz.io CW logs lambda ARN"
@@ -129,3 +134,4 @@ Resources:
           COMPRESS: !Ref LogzioCompress
           ENRICH: !Ref LogzioEnrich
           SENDALL: !Ref LogzioSendAll
+          MAX_LOG_SIZE: !Ref MaxLogSize

--- a/python3/cloudwatch/src/lambda_function.py
+++ b/python3/cloudwatch/src/lambda_function.py
@@ -156,6 +156,6 @@ def lambda_handler(event, context):
             if len(json_log) <= max_size_of_log:
                 shipper.add(log)
             else:
-                logger.warning("Sending to logzio SKIPPED, ignore json string size is " + str(len(json_log)))
+                logger.warning("SKIPPED pushing to logzio, ignored json string size is " + str(len(json_log)))
 
     shipper.flush()


### PR DESCRIPTION
In our case we are getting very huge RDS logs into logzio. I did not see a better way to filter out apart from size of the json. 

I felt this might be useful in the original repository so creating PR. 


Disclaimer: I am not python programmer. I do not know how to run tests in local, I could not find any instructions on `README.md`